### PR TITLE
test-render-scorecard.R: update expected heading

### DIFF
--- a/tests/testthat/test-render-scorecard.R
+++ b/tests/testthat/test-render-scorecard.R
@@ -42,7 +42,7 @@ describe("render scorecard and scorecard summary reports", {
     expect_equal(length(rendered_pdf_toc), 4)
 
     title_sections <- purrr::map_chr(rendered_pdf_toc, ~{.x$title})
-    expect_equal(title_sections, c("Summary", "Principles", "Summary of Proof Points", "System Info"))
+    expect_equal(title_sections, c("Summary", "Background", "Summary of Proof Points", "System Info"))
 
     title_sub_sections <- purrr::map_chr(rendered_pdf_toc[[2]]$children, ~{.x$title})
     expect_equal(length(title_sub_sections), 1)


### PR DESCRIPTION
cf1c219 (#3) renamed the "Principles" heading in
inst/templates/scorecard-summary-template.Rmd to "Background".

---

Note that this test is skipped on drone via `skip_if_render_pdf`.

```
$ git rev-parse HEAD
884a1cdd38f7fccd2278048424f02fd0c54ae185

$ Rscript -e 'devtools::test()'
[1] "/data/home/kylem/scratch/r-pkg-libs/mpn.scorecard/lib"
[2] "/opt/R/4.1.3/lib/R/library"                           
ℹ Testing mpn.scorecard
Using poppler version 0.62.0

Attaching package: ‘dplyr’

The following object is masked from ‘package:testthat’:

    matches

The following objects are masked from ‘package:stats’:

    filter, lag

The following objects are masked from ‘package:base’:

    intersect, setdiff, setequal, union

✔ | F W S  OK | Context
✔ |         6 | create-extra-notes                                                                                     
✔ |        46 | format-report [1.6s]                                                                                   
✔ |        26 | make-traceability-matrix                                                                               
✔ |        17 | mitigation [33.4s]                                                                                     
✔ |        20 | render-scorecard [21.4s]                                                                               
✔ |        69 | results [82.4s]                                                                                        
✔ |        25 | score-pkg [24.5s]                                                                                      
✔ |         9 | summarize-package-results                                                                              

══ Results ════════════════════════════════════════════════════════════════════════════════════════════════════════════
Duration: 164.1 s

[ FAIL 0 | WARN 0 | SKIP 0 | PASS 218 ]
```