### PR TITLE
test-create-extra-notes.R: update create_extra_notes

### DIFF
--- a/tests/testthat/test-create-extra-notes.R
+++ b/tests/testthat/test-create-extra-notes.R
@@ -33,9 +33,7 @@ describe("creating extra notes", {
     case <- setups$pkg_type == "pass_no_functions"
 
     result_dir <- setups$pkg_result_dir[case]
-    pkg_tar <- setups$tar_file[case]
-
-    res <- create_extra_notes(result_dir, pkg_tar)
+    res <- create_extra_notes(result_dir)
     expect_identical(
       res$covr_results_df$r_script,
       "No coverage results"


### PR DESCRIPTION
The new test from 60447c2 (create_extra_notes: handle 'no testable functions' case, 2023-08-18) has a semantic conflict with 23a2c74 (fix create_extra_notes args, 2023-08-17), and the CI merge test didn't catch it due to timing.

Drop the pkg_tar argument.

Re: https://github.com/metrumresearchgroup/mpn.scorecard/pull/23#pullrequestreview-1585001915