### PR TITLE
Trac mat add traceability

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -85,8 +85,8 @@ To add a traceability matrix to the **scorecard**, you must follow the steps bel
 
  - Score the package via `score_pkg`
  - Call `make_traceability_matrix` using the `results_dir` returned from `score_pkg`
- - Set `add_traceability = TRUE` in `render_scorecard`
-   - If an `RDS` file matching the expected naming convention (`<package_tarball_name>.export_doc.rds` or `package_3.1.0.export_doc.rds` in the above example) is found in `results_dir`, the traceability matrix can be picked up. However `add_traceability` must be set to `TRUE` to include this section in the scorecard.
+ 
+If an `RDS` file matching the expected naming convention (`<package_tarball_name>.export_doc.rds` or `package_3.1.0.export_doc.rds` in the above example) is found in `results_dir`, the traceability matrix will be picked up and automatically included. Users can override this by setting `add_traceability` to `FALSE`.
 
 ```{r}
 results_dir <- score_pkg(
@@ -107,7 +107,7 @@ pdf_path <- render_scorecard(
 <img src="man/figures/trac_matrix.png" align="center" style = "width:900px;" />
 
 ## Mitigation (optional)
-Packages with low scores that fall short of initial expectations may include a mitigation text file. The presence of a mitigation section indicates that we are aware the score is low but are proceeding with adding the package to MPN. The rationale for doing so is included in the mitigation file itself. Inclusion of this section works the same as a traceability matrix, but will automatically be included if found. If a mitigation file matching the expected naming convention (`<package_tarball_name>.mitigation.txt` or `package_3.1.0.mitigation.txt` in the above example) is found in `results_dir`, the section *will* be included.
+Packages with low scores that fall short of initial expectations may include a mitigation text file. The presence of a mitigation section indicates that we are aware the score is low but are proceeding with adding the package to MPN. The rationale for doing so is included in the mitigation file itself. Inclusion of this section works the same as a traceability matrix. If a mitigation file matching the expected naming convention (`<package_tarball_name>.mitigation.txt` or `package_3.1.0.mitigation.txt` in the above example) is found in `results_dir`, the section will be automatically be included.
 
 
 ## Summary Report

--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ steps below:
 -   Score the package via `score_pkg`
 -   Call `make_traceability_matrix` using the `results_dir` returned
     from `score_pkg`
--   Set `add_traceability = TRUE` in `render_scorecard`
-    -   If an `RDS` file matching the expected naming convention
-        (`<package_tarball_name>.export_doc.rds` or
-        `package_3.1.0.export_doc.rds` in the above example) is found in
-        `results_dir`, the traceability matrix can be picked up. However
-        `add_traceability` must be set to `TRUE` to include this section
-        in the scorecard.
+
+If an `RDS` file matching the expected naming convention
+(`<package_tarball_name>.export_doc.rds` or
+`package_3.1.0.export_doc.rds` in the above example) is found in
+`results_dir`, the traceability matrix will be picked up and
+automatically included. Users can override this by setting
+`add_traceability` to `FALSE`.
 
 ``` r
 results_dir <- score_pkg(
@@ -126,11 +126,10 @@ include a mitigation text file. The presence of a mitigation section
 indicates that we are aware the score is low but are proceeding with
 adding the package to MPN. The rationale for doing so is included in the
 mitigation file itself. Inclusion of this section works the same as a
-traceability matrix, but will automatically be included if found. If a
-mitigation file matching the expected naming convention
-(`<package_tarball_name>.mitigation.txt` or
+traceability matrix. If a mitigation file matching the expected naming
+convention (`<package_tarball_name>.mitigation.txt` or
 `package_3.1.0.mitigation.txt` in the above example) is found in
-`results_dir`, the section *will* be included.
+`results_dir`, the section will be automatically be included.
 
 ## Summary Report
 

--- a/man/check_for_traceability.Rd
+++ b/man/check_for_traceability.Rd
@@ -4,10 +4,13 @@
 \alias{check_for_traceability}
 \title{Look for Traceability matrix RDS file and return contents if is found}
 \usage{
-check_for_traceability(results_dir)
+check_for_traceability(results_dir, add_traceability)
 }
 \arguments{
 \item{results_dir}{directory containing json file and individual results. Output file path from \code{\link[=score_pkg]{score_pkg()}}}
+
+\item{add_traceability}{Logical (T/F). If \code{TRUE}, append a table that links package functionality to the documentation and test files.
+Defaults to "auto", which will include the matrix if found.}
 }
 \description{
 Look for Traceability matrix RDS file and return contents if is found

--- a/man/render_scorecard.Rd
+++ b/man/render_scorecard.Rd
@@ -8,7 +8,7 @@ render_scorecard(
   results_dir,
   risk_breaks = c(0.3, 0.7),
   overwrite = FALSE,
-  add_traceability = FALSE
+  add_traceability = "auto"
 )
 }
 \arguments{
@@ -22,7 +22,8 @@ is "Medium Risk", and \verb{0.7 <= score < 1} is "High Risk".}
 
 \item{overwrite}{Logical (T/F). If \code{TRUE}, will overwrite an existing file path if it exists}
 
-\item{add_traceability}{Logical (T/F). If \code{TRUE}, append a table that links package functionality to the documentation and test files.}
+\item{add_traceability}{Logical (T/F). If \code{TRUE}, append a table that links package functionality to the documentation and test files.
+Defaults to "auto", which will include the matrix if found.}
 }
 \description{
 Take a JSON from score_pkg() and render a pdf
@@ -30,6 +31,9 @@ Take a JSON from score_pkg() and render a pdf
 \details{
 If a plain text mitigation file is found in \code{results_dir}, it will automatically be included.
 \strong{Note} that it must follow the naming convention of \verb{<pkg_name>_<pkg_version>.mitigation.txt}
+
+If a traceability matrix is found in \code{results_dir}, it will automatically be included unless overridden via \code{add_traceability}.
+\strong{Note} that it must follow the naming convention of \verb{<pkg_name>_<pkg_version>.export_doc.rds}
 
 A mitigation file includes any explanation necessary for justifying use of a potentially "high risk" package.
 }


### PR DESCRIPTION
Change `add_traceability` default per this [comment](https://github.com/metrumresearchgroup/mpn.scorecard/pull/32#issuecomment-1692239663)

 - default "auto" - include the trace matrix if an RDS is found (basically same behavior as the mitigation
 - User can also pass
   - `TRUE` to include. Error if an RDS is not found
   - `FALSE` don't include (no messages needed)
