### PR TITLE
flextable_formatted: avoid as_flextable for non-grouped input

### DIFF
--- a/man/flextable_formatted.Rd
+++ b/man/flextable_formatted.Rd
@@ -10,7 +10,6 @@ flextable_formatted(
   pg_width = 5,
   column_width = NULL,
   doc_type = "PDF",
-  as_flextable = TRUE,
   digits = NULL,
   font_size = 10,
   ...
@@ -28,13 +27,15 @@ If specified, set these column widths before fitting to word document}
 
 \item{doc_type}{Word, PDF, or HTML. Controls font size}
 
-\item{as_flextable}{logical (T/F). if \code{TRUE}, use \code{as_flextable} instead of \code{flextable}, which has different args and is necessary for grouped data}
-
 \item{digits}{numeric. Number of digits to round to. If \code{NULL}, and \code{as_flextable = TRUE}, flextable will round to one digit.}
 
 \item{font_size}{font size of the table.}
 
-\item{...}{additional args to be passed to \code{as_flextable} or \code{flextable}}
+\item{...}{additional args to be passed to \code{as_flextable()} or \code{flextable()}.
+Which function, if any, is called depends on the type of \code{tab}. If \code{tab} is
+already a flextable, neither is called. If \code{tab} inherits from
+"grouped_data", \code{as_flextable()} is called. Otherwise \code{flextable()} is
+called.}
 }
 \value{
 a formatted flextable


### PR DESCRIPTION
Our flextable_formatted() helper converts input to a flextable with `flextable::as_flextable()` when the as_flextable flag is TRUE.  Two spots call flextable_formatted() with a data frame as the input and as_flextable=TRUE:

 * format_overall_scores() when creating the "Package Risk Metrics Summary" table

 * format_metadata() when creating the "System Information" table

The latest flextable version (0.9.3) includes b3d8cba8 (change: `as_flextable.data.frame()` always shows the number of rows even if less than 10, 2023-09-06).  With that commit, the as_flextable() output for a data frame will always add a footer reporting the number of rows ("n: N").  We don't want that for either of the above tables.

The as_flextable() conversion is only needed for grouped_data input, as used by format_package_details() to create the "Package Details" table.  Drop the as_flextable flag, and instead determine whether to use as_flextable() or flextable() based on the input type.

---

### Examples

#### output with flextable 0.9.2  and mpn.scorecard `main` (24a43de)

![image](https://github.com/metrumresearchgroup/mpn.scorecard/assets/1297788/6b7a3bec-a83f-49bb-878e-084f0e7f996b)

#### output with flextable 0.9.3  and mpn.scorecard `main` (24a43de)

![image](https://github.com/metrumresearchgroup/mpn.scorecard/assets/1297788/24d22b75-cdea-43a9-b6d2-137e758ecf14)

#### output with flextable 0.9.3 and this PR

![image](https://github.com/metrumresearchgroup/mpn.scorecard/assets/1297788/f1419d70-89ea-4c07-ba80-b27c6bae55c7)
 

