### PR TITLE
DESCRIPTION: drop packages from Imports that aren't used in R/

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,11 +31,9 @@ Imports:
     flextable (>= 0.8.4),
     fs,
     glue,
-    here,
     jsonlite,
     knitr,
     magrittr,
-    markdown,
     officer,
     pkgload,
     purrr,
@@ -45,13 +43,13 @@ Imports:
     rmarkdown,
     stringr,
     tibble,
-    tidyr,
     tidyselect
 Suggests:
     devtools,
     pdftools,
     roxygen2,
     testthat (>= 2.1.0),
+    tidyr,
     withr
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3

--- a/pkgr.yml
+++ b/pkgr.yml
@@ -4,6 +4,7 @@ Descriptions:
 
 Packages:
   - devtools
+  - here
   - pkgdown
   - styler
 


### PR DESCRIPTION
The 'R CMD check' for mpn.scorecard has the following note [*]:

    Namespaces in Imports field not imported from:
       ‘here’ ‘markdown’ ‘tidyr’
      All declared Imports should be used.

here is only used in the top-level update-readme.R, not in any R/ code, so move it to pkgr.yml.

tidyr is only used in test code, so move it to Suggests.

markdown isn't used at all, so just remove it.

[*] This isn't flagged by the default `devtools::check()` (which
    passes --as-cran) until R 4.2 (see revision 81155).