### PR TITLE
render_scorecard: list dependencies and versions in appendix table

### DIFF
--- a/R/format-report.R
+++ b/R/format-report.R
@@ -307,11 +307,43 @@ format_metadata <- function(metadata_list){
     flextable::align(align = "center", part = "all") %>%
     flextable::color(color = "black", part = "body") %>%
     flextable::set_header_labels(Category = "Category", Value = "Value") %>%
-    flextable::set_caption("System Information")
+    flextable::set_caption("Execution and Machine Information")
 
   return(system_info_flextable)
 }
 
+# `cat_dependency_versions` would be a more fitting name (given cat() and
+# format()), but "format_" is used for consistency with other functions in this
+# file.
+format_dependency_versions <- function(df) {
+  out <- prepare_dependency_versions(df)
+  if (inherits(out, "flextable")) {
+    # Note: knit_print.flextable() does _not_ print to stdout.
+    out <- knitr::knit_print(out)
+  }
+  cat("\n\n", out, "\n\n")
+}
+
+prepare_dependency_versions <- function(df) {
+  if (is.null(df)) {
+    return("Unable to calculate R dependency table due to failing `R CMD check`.")
+  }
+
+  checkmate::assert_data_frame(df)
+  checkmate::assert_subset(c("package", "version"), names(df))
+
+  if (nrow(df) == 0) {
+    return("Package has no required dependencies.")
+  }
+
+  flextable_formatted(df) %>%
+    flextable::set_caption("R Dependency Versions") %>%
+    flextable::set_header_labels(package = "Package", version = "Version") %>%
+    # TODO: Create helper to avoid repeating these next lines in several spots.
+    flextable::bg(bg = "#ffffff", part = "all") %>%
+    flextable::align(align = "center", part = "all") %>%
+    flextable::color(color = "black", part = "body")
+}
 
 #' Format vector of mitigation text
 #'

--- a/inst/templates/scorecard-template.Rmd
+++ b/inst/templates/scorecard-template.Rmd
@@ -25,6 +25,7 @@ params:
   mitigation_block: "r NULL"
   extra_notes_data: "r NULL"
   exports_df: "r NULL"
+  dep_versions_df: "`r NA`"
 title: >
   `r params$set_title`
 subtitle: 'MPN Scorecard'
@@ -90,6 +91,13 @@ format_traceability_matrix(params$exports_df)
 ## System Info
 ```{r}
 format_metadata(formatted_pkg_scores$metadata)
+```
+
+```{r, results = "asis"}
+if (identical(params$dep_versions_df, NA)) {
+  stop("Required versions_df parameter not specified.")
+}
+format_dependency_versions(params$dep_versions_df)
 ```
 
 ```{r, results = "asis"}


### PR DESCRIPTION
When building MPN or scoring a package with our internal helper script, we can determine which dependencies were used because we know the overall set of available packages.  That's not true in general, so it'd be good to include information about the version of dependencies that were used.

Calling sessionInfo() in the main session won't do what we want because that will only capture loaded/attached packages for the current session.  Both rcmdcheck and covr run in a subprocess.

rcmdcheck already captures the some session info via the sessioninfo::session_info() package (using some fairly complicated logic to hook into the `R CMD check` subprocess).  That includes a data frame of package names and versions for the package's dependencies [*].  Include that as a table in the appendix.

This new table falls under "System Info", so put it in that section. The other table in that section is called "System Information", but that table also contains info about the execution, so rename it to "Execution and Machine Information".

[*] Unfortunately that call uses the default value for the
    `dependencies` argument, so suggested packages are not included.
    It's worth a feature request to rcmdcheck to support including
    suggested packages, but for now recording the hard dependency
    versions is better than nothing.

Closes #39.

---

This is ready to review, but I'm marking it as a draft because it should be merged until gh-43 lands.

Example output for new table:

![image](https://github.com/metrumresearchgroup/mpn.scorecard/assets/1297788/1883d5d0-8009-489a-a499-86b78782b86c)

Above I said:

> This new table falls under "System Info", so put it in that section. The other table in that section is called "System Information", but that table also contains info about the execution, so rename it to "Execution and Machine Information".

That felt like the most natural spot to me, but I'm of course open to suggestions about other spots to put it (e.g., under its own header).