### PR TITLE
scorecard-summary-template.Rmd: don't set link-citations to true

### DIFF
--- a/inst/templates/scorecard-summary-template.Rmd
+++ b/inst/templates/scorecard-summary-template.Rmd
@@ -10,7 +10,6 @@ output:
     citation_package: biblatex
 bibliography: ["sum_links.bib"]
 biblio-style: "apalike"
-link-citations: true
 # needed to make footnotes point to full bibliography
 csl: https://www.zotero.org/styles/chicago-fullnote-bibliography
 # needed to prevent additional bibliography section


### PR DESCRIPTION
The summary template sets 'link-citations: true' and 'suppress-bibliography: true', using footnotes for bibliography entries.  Before version 3.1.7, pandoc accepts both link-citations and suppress-bibliography being true, though link-citations has no effect. link-citations is only relevant for the omitted bibliography section, not the footnotes.

Starting with 3.1.7, pandoc will generate an invalid tex file if both link-citations and suppress-bibliography are true.  The issue is resolved in the recent pandoc 3.1.10 release [*].

Drop 'link-citations: true' to make render_scorecard_summary() compatible with pandoc 3.1.7 up to 3.1.9.  I've verified with pandoc 2.17.1.1 and 3.1.8 that links to the bibliography footnotes are still present.

[*] https://github.com/jgm/pandoc/issues/9163