### PR TITLE
Bug fix: tidyr is not listed as an import

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,6 @@ Suggests:
     pdftools,
     roxygen2,
     testthat (>= 2.1.0),
-    tidyr,
     withr
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,8 @@ Imports:
     rmarkdown,
     stringr,
     tibble,
-    tidyselect
+    tidyselect,
+    tidyr
 Suggests:
     devtools,
     pdftools,


### PR DESCRIPTION
 - it's used in `format_traceability_matrix`. Not sure how R CMD Check missed this.


I haven't done a thorough investigation here, but it may only be used in this one spot. If that's the case, we may want to look for another solution, rather than adding it as an import