### PR TITLE
readme: Add new line before summary table

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -145,4 +145,5 @@ browseURL(pdf_sum_path)
 ```
 
 The report provides additional context, session info, proof points, etc., but will render a table that looks like the one below:
+
 <img src="man/figures/summary_tab.png" align="center" style = "width:750px;" />

--- a/README.md
+++ b/README.md
@@ -170,4 +170,5 @@ browseURL(pdf_sum_path)
 
 The report provides additional context, session info, proof points,
 etc., but will render a table that looks like the one below:
+
 <img src="man/figures/summary_tab.png" align="center" style = "width:750px;" />


### PR DESCRIPTION
Add new line before summary table

Prevents table from looking like this:
![image](https://github.com/metrumresearchgroup/mpn.scorecard/assets/18685116/75f4980f-0236-48a8-8fbf-58d0420652b6)
