### PR TITLE
doc: update some param names to match code

### DIFF
--- a/R/format-report.R
+++ b/R/format-report.R
@@ -160,8 +160,8 @@ flex_footer <- function(
 #' Helper to apply flextable styling for alternating row background color
 #'
 #' @param tab a flextable
-#' @param odd_body,even_body the background color of odd and even rows for the
-#'   main body of `tab`. Note that all font is black for the body.
+#' @param odd_body_bg,even_body_bg the background color of odd and even rows for
+#'   the main body of `tab`. Note that all font is black for the body.
 #' @param border Logical (T/F). If `TRUE`, add horizontal borders and a vertical
 #'   border after the first column.
 #' @keywords internal

--- a/R/util.R
+++ b/R/util.R
@@ -125,7 +125,7 @@ deprecate_warning <- function(version, what, details = NULL){
 #' @param strict logical (T/F). If `FALSE`, will soft wrap based on the
 #'  characters specified via `wrap_sym`. If `TRUE`, will first soft wrap, and then
 #'  enforce the specified `width`.
-#' @param intent logical (T/F). If `TRUE`, indent new lines by two spaces.
+#' @param indent logical (T/F). If `TRUE`, indent new lines by two spaces.
 #'
 #' @details
 #' `stringr::str_wrap` is not strict with the width for word characters, so

--- a/man/flex_stripe.Rd
+++ b/man/flex_stripe.Rd
@@ -14,11 +14,11 @@ flex_stripe(
 \arguments{
 \item{tab}{a flextable}
 
+\item{odd_body_bg, even_body_bg}{the background color of odd and even rows for
+the main body of \code{tab}. Note that all font is black for the body.}
+
 \item{border}{Logical (T/F). If \code{TRUE}, add horizontal borders and a vertical
 border after the first column.}
-
-\item{odd_body, even_body}{the background color of odd and even rows for the
-main body of \code{tab}. Note that all font is black for the body.}
 }
 \description{
 Helper to apply flextable styling for alternating row background color

--- a/man/wrap_text.Rd
+++ b/man/wrap_text.Rd
@@ -25,7 +25,7 @@ Note that the order you specify these values matters.}
 characters specified via \code{wrap_sym}. If \code{TRUE}, will first soft wrap, and then
 enforce the specified \code{width}.}
 
-\item{intent}{logical (T/F). If \code{TRUE}, indent new lines by two spaces.}
+\item{indent}{logical (T/F). If \code{TRUE}, indent new lines by two spaces.}
 }
 \description{
 Wrap a vector of strings using specific characters


### PR DESCRIPTION
These mismatches were flagged by a check under R 4.4.0.

Re: gh-62

---


https://github.com/metrumresearchgroup/mpn.scorecard/actions/runs/8931121664/job/24532605320?pr=62

```
Documented arguments not in \usage in Rd file 'flex_stripe.Rd':
  ‘odd_body’ ‘even_body’
Documented arguments not in \usage in Rd file 'wrap_text.Rd':
  ‘intent’
```