### PR TITLE
wrapi_text: don't process NA input

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -162,6 +162,10 @@ wrapi_text <- function(
 
   checkmate::assert_character(str)
   checkmate::assert_true(length(str) == 1)
+  if (is.na(str)) {
+    return(str)
+  }
+
   str_new <- str
 
   # Get max number of characters per line (splits on '\n')

--- a/tests/testthat/test-format-report.R
+++ b/tests/testthat/test-format-report.R
@@ -155,6 +155,32 @@ describe("formatting functions", {
     expect_equal(unique(test_files), c("test-myscript.R", ""))
   })
 
+  it("format_traceability_matrix: exports missing def", {
+    scenario <- dplyr::filter(
+      pkg_dirs[["pkg_setups_df"]],
+      pkg_type == "fail_func_syntax"
+    )
+    stopifnot(nrow(scenario) == 1)
+    res_dir <- scenario[["pkg_result_dir"]]
+    tarfile <- scenario[["tar_file"]]
+
+    export_doc_path <- get_result_path(res_dir, "export_doc.rds")
+    on.exit(unlink(export_doc_path))
+
+    expect_false(fs::file_exists(export_doc_path))
+    expect_warning(
+      exports_df <- make_traceability_matrix(res_dir, pkg_tar_path = tarfile),
+      "Failed to parse"
+    )
+    expect_true(fs::file_exists(export_doc_path))
+
+    tbl <- format_traceability_matrix(exports_df)
+    expect_equal(
+      unique(unname(unlist(tbl$footer$dataset))),
+      "Testing directories: tests/testthat"
+    )
+  })
+
   it("format_appendix", {
     pkg_setup_select <- pkg_dirs$pkg_setups_df %>% dplyr::filter(pkg_type == "pass_success")
     result_dir_x <- pkg_setup_select$pkg_result_dir


### PR DESCRIPTION
Calling format_traceability_matrix() for a package where some exports in the namespace weren't mapped to an R/ file (as is the case with mrgsolve) leads to an error following gh-57, which was included in the mpn.scorecard 0.4.0 release.

The root of the error is wrapi_text() using an NA result in a condition.  There's nothing for wrapi_text() to do with NA input, so update it to return the NA input as is.

Closes #64.