### PR TITLE
Prepare 0.4.1 release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,6 +40,9 @@ jobs:
             any::rcmdcheck
           upgrade: 'TRUE'
       - uses: r-lib/actions/check-r-package@v2
+      - name: Check pkgdown
+        shell: Rscript {0}
+        run: pkgdown::check_pkgdown()
   release:
     if: github.ref_type == 'tag'
     name: Upload release

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mpn.scorecard
 Title: Generate a scorecard with various measures of R package quality and risk
-Version: 0.4.0
+Version: 0.4.1
 Authors@R: 
     c(person(given = "Kyle",
            family = "Barrett",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# mpn.scorecard 0.4.1
+
+## Bug Fixes
+
+ - Due to a regression in the 0.4.0 release, an error was triggered when
+   formatting the traceability matrix of a package with exports in its namespace
+   that couldn't be mapped to a code file. (#65)
+
 # mpn.scorecard 0.4.0
 
 ## New features and change


### PR DESCRIPTION
changeset: https://github.com/metrumresearchgroup/mpn.scorecard/compare/0.4.0...release/0.4.1

In addition to the standard release bits, this adds a `check_pkgdown` step to the CI to help catch pkgdown issues before release (e.g, we often get bit by missing index entries).

<details>
<summary>mpn.scorecard scores</summary>

```json
{
  "testing": {
    "check": 1,
    "covr": 0.9395
  },
  "documentation": {
    "has_vignettes": 0,
    "has_website": 1,
    "has_news": 1
  },
  "maintenance": {
    "has_maintainer": 1,
    "news_current": 1
  },
  "transparency": {
    "has_source_control": 1,
    "has_bug_reports_url": 1
  }
}
```

[ This was scored with the tip of this branch (`--scorecard-version=599424b`), though that doesn't matter because `mpn.scorecard` isn't affected by the bug fixed in this release. ]

</details>

