### PR TITLE
DESCRIPTION: add pkgdown site to URL field

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Authors@R:
 Description: Collects various measures of quality and risk-of-use for an R package
     and formats them into a "scorecard" report for assessment. Leans heavily on 
     the metrics developed by R Validation Hub's riskmetric package.
-URL: https://github.com/metrumresearchgroup/mpn.scorecard
+URL: https://metrumresearchgroup.github.io/mpn.scorecard, https://github.com/metrumresearchgroup/mpn.scorecard
 BugReports: https://github.com/metrumresearchgroup/mpn.scorecard/issues
 License: MIT + file LICENSE
 Encoding: UTF-8


### PR DESCRIPTION
As of pkgdown 2.1.0, check_pkgdown() fails with

    Error in `pkgdown::check_pkgdown()`:
    ! In DESCRIPTION, URL is missing package url
    (https://metrumresearchgroup.github.io/mpn.scorecard).
    ℹ See details in `vignette(pkgdown::metadata)`.

The main advantage of listing the pkgdown site in the DESCRIPTION's URL field is that it enables pkgdown to auto-link to mpn.scorecard pages when building another package's site.

https://pkgdown.r-lib.org/articles/linking.html#across-packages