### PR TITLE
ci: update R versions to cover latest Metworx

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,9 @@ jobs:
           - os: ubuntu-20.04
             r: 4.0.5
           - os: ubuntu-20.04
-            r: 4.1.3
+            r: 4.2.3
+          - os: ubuntu-20.04
+            r: 4.3.1
           - os: ubuntu-latest
             r: release
     env:


### PR DESCRIPTION

There are jobs for R 4.0.5 and 4.1.3 to match the two most recent R versions on Metworx.  A new Metworx AMI (24.04) recently came out, and its two latest R versions are 4.2.3 and 4.3.1.

Add jobs for those versions.

Retain the R 4.0.5 job to help flag incompatibles with the previous AMI (22.09).  Drop the R 4.1.3 job because it's not likely to catch something that wouldn't be caught by the other jobs.

---

- [x] wait for gh-67 to be merged
- [x] adjust required checks (drop 4.1.3, add 4.2.3 and 4.3.1)