### PR TITLE
text wrapping fixes

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -182,7 +182,8 @@ wrapi_text <- function(
     }
 
     start <- NULL; shift <- 0
-    for(i in 2:length(pieces)){
+    npieces <- length(pieces)
+    for (i in 2:npieces) {
       pieces_sep <- pieces[(1 + shift):i]
       add <- paste0(pieces_sep, collapse = wrap_chr)
       s <- cat_start(start = start, add = add, sep = wrap_chr)
@@ -191,7 +192,7 @@ wrapi_text <- function(
       }else{
         pieces_start <- pieces[(1 + shift):(i-1)]
         add <- paste(paste0(pieces_start, collapse = wrap_chr), pieces[i], sep = newline_sep)
-        if(i == length(pieces)){
+        if (i == npieces) {
           s <- cat_start(start = start, add = add, sep = wrap_chr)
         }else{
           start <- cat_start(start = start, add = add, sep = wrap_chr)

--- a/R/util.R
+++ b/R/util.R
@@ -192,9 +192,9 @@ wrapi_text <- function(
         pieces_start <- pieces[(1 + shift):(i-1)]
         add <- paste(paste0(pieces_start, collapse = wrap_chr), pieces[i], sep = newline_sep)
         if(i == length(pieces)){
-          s <- cat_start(start = start, add = add, sep = newline_sep)
+          s <- cat_start(start = start, add = add, sep = wrap_chr)
         }else{
-          start <- cat_start(start = start, add = add, sep = newline_sep)
+          start <- cat_start(start = start, add = add, sep = wrap_chr)
           shift <- shift + i
         }
       }

--- a/R/util.R
+++ b/R/util.R
@@ -160,8 +160,7 @@ wrapi_text <- function(
     indent = FALSE
 ){
 
-  checkmate::assert_character(str)
-  checkmate::assert_true(length(str) == 1)
+  checkmate::assert_string(str, na.ok = TRUE)
   if (is.na(str)) {
     return(str)
   }

--- a/R/util.R
+++ b/R/util.R
@@ -191,8 +191,14 @@ wrapi_text <- function(
       if(max_line_char(s) <= width){
         next
       }else{
-        pieces_start <- pieces[shift:(i - 1)]
-        add <- paste(paste0(pieces_start, collapse = wrap_chr), pieces[i], sep = newline_sep)
+        if (shift == i) {
+          # `start` includes everything aside from the current piece.
+          add <- paste0("\n", pieces[i])
+        } else {
+          pieces_start <- pieces[shift:(i - 1)]
+          add <- paste(paste0(pieces_start, collapse = wrap_chr), pieces[i], sep = newline_sep)
+        }
+
         if (i == npieces) {
           s <- cat_start(start = start, add = add, sep = wrap_chr)
         }else{

--- a/R/util.R
+++ b/R/util.R
@@ -181,22 +181,23 @@ wrapi_text <- function(
       if(is.null(start)) add else paste(start, add, sep = sep)
     }
 
-    start <- NULL; shift <- 0
+    start <- NULL
+    shift <- 1
     npieces <- length(pieces)
     for (i in 2:npieces) {
-      pieces_sep <- pieces[(1 + shift):i]
+      pieces_sep <- pieces[shift:i]
       add <- paste0(pieces_sep, collapse = wrap_chr)
       s <- cat_start(start = start, add = add, sep = wrap_chr)
       if(max_line_char(s) <= width){
         next
       }else{
-        pieces_start <- pieces[(1 + shift):(i-1)]
+        pieces_start <- pieces[shift:(i - 1)]
         add <- paste(paste0(pieces_start, collapse = wrap_chr), pieces[i], sep = newline_sep)
         if (i == npieces) {
           s <- cat_start(start = start, add = add, sep = wrap_chr)
         }else{
           start <- cat_start(start = start, add = add, sep = wrap_chr)
-          shift <- shift + i
+          shift <- i + 1
         }
       }
     }

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -34,3 +34,10 @@ test_that("wrap_text() works", {
   expect_equal(wrap_str, "test-modify-model-\nfield.R\ntest-submit-models.R")
   expect_equal(max_line_char(wrap_str), 20)
 })
+
+test_that("wrap_text(): past offenders", {
+  expect_identical(
+    wrap_text("abcde", width = 2, wrap_sym = NULL, strict = TRUE),
+    "ab\ncd\ne"
+  )
+})

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -40,4 +40,25 @@ test_that("wrap_text(): past offenders", {
     wrap_text("abcde", width = 2, wrap_sym = NULL, strict = TRUE),
     "ab\ncd\ne"
   )
+
+  expect_identical(
+    wrap_text("abcdefghij", width = 4, wrap_sym = NULL, strict = TRUE),
+    "abcd\nefgh\nij"
+  )
+
+  expect_identical(
+    wrap_text(
+      "test-foo.R\ntest-foo_bar.R",
+      width = 8, wrap_sym = NULL, strict = TRUE
+    ),
+    "test-foo\n.R\ntest-foo\n_bar.R"
+  )
+
+  expect_identical(
+    wrap_text(
+      "test-foo.R\ntest-foo_bar.R",
+      width = 4, wrap_sym = NULL, strict = TRUE
+    ),
+    "test\n-foo\n.R\ntest\n-foo\n_bar\n.R"
+  )
 })

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -61,4 +61,9 @@ test_that("wrap_text(): past offenders", {
     ),
     "test\n-foo\n.R\ntest\n-foo\n_bar\n.R"
   )
+
+  expect_identical(
+    wrap_text("foo/bar/baz", width = 4),
+    "foo/\nbar/\nbaz"
+  )
 })


### PR DESCRIPTION
This series fixes three `wrap_text()` bugs.  I started looking into this because rendering the scorecards for six packages on MPN (gsDesign, mlr, pals, r2rtf, tidyposterior, and vcr) failed with a TeX error related to long lines ("Unable to read an entire line...").  The failure was introduced by 773c9ee (bug fix and refactor: tracability matrix, 2024-03-19, gh-57).

That failure is resolved by the fourth commit ("wrapi_text: fix indexing logic").  The second and fifth commits have the other two fixes.

---

- [x] wait for gh-67 and gh-68 to land
