### PR TITLE
render_scorecard: fix recent regression in relative path handling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mpn.scorecard
 Title: Generate a scorecard with various measures of R package quality and risk
-Version: 0.4.1
+Version: 0.4.1.8000
 Authors@R: 
     c(person(given = "Kyle",
            family = "Barrett",

--- a/R/render-scorecard.R
+++ b/R/render-scorecard.R
@@ -39,13 +39,17 @@ render_scorecard <- function(
   } else {
     param_fn <- get_render_params
   }
+  # Note: this should be evaluated outside of the rmarkdown::render() call
+  # because render() changes the directory before evaluating its params
+  # argument, breaking relative path handling.
+  pars <- param_fn(results_dir, risk_breaks, add_traceability)
 
   rendered_file <- rmarkdown::render(
     system.file(SCORECARD_RMD_TEMPLATE, package = "mpn.scorecard", mustWork = TRUE), # TODO: do we want to expose this to users, to pass their own custom template?
     output_dir = results_dir,
     output_file = basename(out_file),
     quiet = TRUE,
-    params = param_fn(results_dir, risk_breaks, add_traceability)
+    params = pars
   )
 
   return(invisible(rendered_file))

--- a/tests/testthat/test-render-scorecard.R
+++ b/tests/testthat/test-render-scorecard.R
@@ -29,6 +29,14 @@ describe("render scorecard and scorecard summary reports", {
     }
   })
 
+  it("render_scorecard - relative path", {
+    rdir <- result_dirs_select[1]
+    withr::with_dir(dirname(rdir), {
+      pdf_path <- render_scorecard(basename(rdir), overwrite = TRUE)
+      on.exit(fs::file_delete(fs::path_abs(pdf_path)), add = TRUE)
+    })
+  })
+
   it("render_scorecard - with traceability matrix", {
 
     # `result_dirs_select` defined in tests/testthat/setup.R


### PR DESCRIPTION
This PR fixes  breakage that @barrettk noticed when calling our internal `score-r-pkg` script and telling it to use a recent mpn.scorecard commit (a0efd0a70e69b).  See the first commit's message for details.

I threw in the second commit to bump to a dev version.  That's something I need for bbi and pkgr.  (No plans to tag it unless someone requests it.)
