### PR TITLE
Fix: `split_long_rows` when no mappings occur

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,6 +35,9 @@ jobs:
           r-version: ${{ matrix.config.r }}
           use-public-rspm: true
           extra-repositories: 'https://mpn.metworx.com/snapshots/stable/${{ env.MPN_LATEST }}'
+      - name: Install additional system dependencies
+        shell: bash
+        run: sudo apt-get install libpoppler-cpp-dev
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
@@ -61,6 +64,9 @@ jobs:
           r-version: release
           use-public-rspm: true
           extra-repositories: 'https://mpn.metworx.com/snapshots/stable/${{ env.MPN_LATEST }}'
+      - name: Install additional system dependencies
+        shell: bash
+        run: sudo apt-get install libpoppler-cpp-dev
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::pkgpub

--- a/R/format-report.R
+++ b/R/format-report.R
@@ -831,22 +831,19 @@ split_long_rows <- function(exported_func_df, n = 40) {
       purrr::map_dfr(1:n_chunks, function(i) {
         new_row <- row_data
 
-        code_split_len <- length(new_row$code_file_split[[1]])
-        doc_split_len <- length(new_row$documentation_split[[1]])
-        test_split_len <- length(new_row$test_files_split[[1]])
         # Extract split contents or default to an empty string
         new_row$code_file <- ifelse(
-          code_split_len >= i && code_split_len != 0,
+          length(new_row$code_file_split[[1]]) >= i,
           new_row$code_file_split[[1]][[i]],
           ""
         )
         new_row$documentation <- ifelse(
-          doc_split_len >= i && doc_split_len != 0,
+          length(new_row$documentation_split[[1]]) >= i,
           new_row$documentation_split[[1]][[i]],
           ""
         )
         new_row$test_files <- ifelse(
-          test_split_len >= i && test_split_len != 0,
+          length(new_row$test_files_split[[1]]) >= i,
           new_row$test_files_split[[1]][[i]],
           ""
         )

--- a/R/format-report.R
+++ b/R/format-report.R
@@ -828,7 +828,7 @@ split_long_rows <- function(exported_func_df, n = 40) {
       )
 
       # Create a list of new rows
-      purrr::map_dfr(1:n_chunks, function(i) {
+      purrr::map_dfr(seq_len(n_chunks), function(i) {
         new_row <- row_data
 
         # Extract split contents or default to an empty string

--- a/R/format-report.R
+++ b/R/format-report.R
@@ -818,27 +818,35 @@ split_long_rows <- function(exported_func_df, n = 40) {
     # Expand each row if any of the splits are greater than 1
     dplyr::group_split() %>%
     purrr::map_dfr(function(row_data) {
-      n_chunks <- max(length(row_data$code_file_split[[1]]),
-                      length(row_data$documentation_split[[1]]),
-                      length(row_data$test_files_split[[1]]))
+      n_chunks <- max(
+        length(row_data$code_file_split[[1]]),
+        length(row_data$documentation_split[[1]]),
+        length(row_data$test_files_split[[1]]),
+        # Ensure the minimum value is at least 1
+        # i.e. when columns code_file, documentation, and test_files are all empty
+        1
+      )
 
       # Create a list of new rows
       purrr::map_dfr(1:n_chunks, function(i) {
         new_row <- row_data
 
+        code_split_len <- length(new_row$code_file_split[[1]])
+        doc_split_len <- length(new_row$documentation_split[[1]])
+        test_split_len <- length(new_row$test_files_split[[1]])
         # Extract split contents or default to an empty string
         new_row$code_file <- ifelse(
-          length(new_row$code_file_split[[1]]) >= i,
+          code_split_len >= i && code_split_len != 0,
           new_row$code_file_split[[1]][[i]],
           ""
         )
         new_row$documentation <- ifelse(
-          length(new_row$documentation_split[[1]]) >= i,
+          doc_split_len >= i && doc_split_len != 0,
           new_row$documentation_split[[1]][[i]],
           ""
         )
         new_row$test_files <- ifelse(
-          length(new_row$test_files_split[[1]]) >= i,
+          test_split_len >= i && test_split_len != 0,
           new_row$test_files_split[[1]][[i]],
           ""
         )


### PR DESCRIPTION
Previously, `split_long_rows` would error out if columns `code_file`, `documentation`, and `test_files` were _all_ empty.

 - Add overall and regression test for `split_long_rows`
 - tested with MPN failures `bit64` and `gdata`

closes https://github.com/metrumresearchgroup/mpn.scorecard/issues/75