### PR TITLE
Column wrapping tweaks

### DIFF
--- a/R/format-report.R
+++ b/R/format-report.R
@@ -709,7 +709,7 @@ format_traceability_matrix <- function(
               cell[is.na(cell)] <- ""
               # Wrap text
               if(isTRUE(wrap_cols)){
-                cell <- wrap_text(cell, width = 24, indent = TRUE, strict = TRUE)
+                cell <- wrap_text(cell, width = 20, indent = TRUE, strict = TRUE)
               }
               paste(cell, collapse = "\n")
             })

--- a/R/util.R
+++ b/R/util.R
@@ -144,7 +144,7 @@ deprecate_warning <- function(version, what, details = NULL){
 wrap_text <- function(
     str,
     width = 23,
-    wrap_sym = c("/", "_", "-"),
+    wrap_sym = c("/", "_", "-", " "),
     strict = FALSE,
     indent = FALSE
 ){
@@ -160,7 +160,7 @@ wrap_text <- function(
 wrapi_text <- function(
     str,
     width = 23,
-    wrap_sym = c("/", "_", "-"),
+    wrap_sym = c("/", "_", "-", " "),
     strict = FALSE,
     indent = FALSE
 ){

--- a/R/util.R
+++ b/R/util.R
@@ -229,8 +229,26 @@ wrapi_text <- function(
 
   # Check if `wrap_sym` characters ensured required width
   if(max_line_char(str_new) > width && isTRUE(strict)){
-    pieces <- unlist(strsplit(str_new, ""))
-    str_new <- paste_pieces(pieces, wrap_chr = "", width)
+    # Try first to get it under the specified width by breaking at mid-string
+    # capital letters.
+    if (isTRUE(grepl("[a-z][A-Z]", str_new))) {
+      # delim can be any stretch of non-regex characters that won't
+      # realistically occur in the string.
+      delim <- "\fBREAK\f"
+      pieces <- unlist(
+        strsplit(
+          gsub("([a-z])([A-Z])", paste0("\\1", delim, "\\2"), str_new),
+          delim,
+          fixed = TRUE
+        )
+      )
+      str_new <- paste_pieces(pieces, wrap_chr = "", width)
+    }
+    # Finally fall back to just breaking it anywhere.
+    if (max_line_char(str_new) > width) {
+      pieces <- unlist(strsplit(str_new, ""))
+      str_new <- paste_pieces(pieces, wrap_chr = "", width)
+    }
   }
 
   # Indent new lines if only one line -initially- existed

--- a/man/wrap_text.Rd
+++ b/man/wrap_text.Rd
@@ -7,7 +7,7 @@
 wrap_text(
   str,
   width = 23,
-  wrap_sym = c("/", "_", "-"),
+  wrap_sym = c("/", "_", "-", " "),
   strict = FALSE,
   indent = FALSE
 )

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -67,3 +67,14 @@ test_that("wrap_text(): past offenders", {
     "foo/\nbar/\nbaz"
   )
 })
+
+test_that("wrap_text() breaks on spaces by default", {
+  expect_identical(
+    wrap_text("foo bar baz", width = 8),
+    "foo bar \nbaz"
+  )
+  expect_identical(
+    wrap_text("foo bar baz", width = 5),
+    "foo \nbar \nbaz"
+  )
+})

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -78,3 +78,18 @@ test_that("wrap_text() breaks on spaces by default", {
     "foo \nbar \nbaz"
   )
 })
+
+test_that("wrap_text(): strict fallback prefers breaking at capital letter", {
+  expect_identical(
+    wrap_text("diffPreviousRevisions", width = 20, strict = TRUE),
+    "diffPrevious\nRevisions"
+  )
+  expect_identical(
+    wrap_text("diffPreviousRevisions", width = 10, strict = TRUE),
+    "diff\nPrevious\nRevisions"
+  )
+  expect_identical(
+    wrap_text("diffPreviousRevisions", width = 5, strict = TRUE),
+    "diff\nPrevi\nous\nRevis\nions"
+  )
+})


### PR DESCRIPTION
When preparing to use mpn.scorecard for Torsten, some of entry points in the matrix ran into the next column.  The main purpose of this PR is to avoid that by decreasing the specified column width.  (See last commit for information.)

In addition, this PR makes two more wrapping tweaks:

 * for strict mode, prefer breaking at mid-string capital letters

   This relates to the decreased column width.  With the width change, I noticed that review's `diffPreviousRevisions` was getting unpleasantly wrapped so that the final `s` was on the second line.  By considering mid-string capital letters, the break instead happens before `Revisions`.

 * add space to the default `wrap_sym` value

   This makes it more likely that CLI entry points find a good break point, which becomes more relevant as we decrease the widths.  (However, none of the CLIs that we currently score have entry points that exceed the new width, so it doesn't matter at this point.)
