### PR TITLE
test-render-scorecard.R: add assertion to prevent subtest skip

### DIFF
--- a/tests/testthat/test-render-scorecard.R
+++ b/tests/testthat/test-render-scorecard.R
@@ -34,6 +34,7 @@ describe("render scorecard and scorecard summary reports", {
     withr::with_dir(dirname(rdir), {
       pdf_path <- render_scorecard(basename(rdir), overwrite = TRUE)
       on.exit(fs::file_delete(fs::path_abs(pdf_path)), add = TRUE)
+      checkmate::expect_file_exists(pdf_path)
     })
   })
 


### PR DESCRIPTION
`test-render-scorecard.R` has a regression test that checks that `render_scorecard` doesn't error when called with a relative path.  This subtest is skipped as of testthat 3.3.0 (specifically 2e911f4a) because it doesn't have any assertions.

Add an assertion that the PDF output file exists so that the subtest is executed.

Fixes #85.

---

- [x] Wait for merge of base (gh-86)